### PR TITLE
Add a hook to prepare the audio session

### DIFF
--- a/AGAudioPlayer/AGAudioPlayer.h
+++ b/AGAudioPlayer/AGAudioPlayer.h
@@ -103,6 +103,9 @@ downloadedBytesForActiveTrack:(uint64_t)downloadedBytes
 
 - (void)setIndex:(NSInteger)index;
 
+// prepareAudioSession automatically be called before playback, but is exposed if you'd like to prepare the session earlier.
+- (void)prepareAudioSession;
+
 - (void)resume;
 - (void)pause;
 - (void)stop;

--- a/AGAudioPlayer/AGAudioPlayer.m
+++ b/AGAudioPlayer/AGAudioPlayer.m
@@ -371,6 +371,10 @@
     self.bass.dataSource = self;
 }
 
+- (void)prepareAudioSession {
+    [self.bass prepareAudioSession];
+}
+
 - (void)teardownBASS {
     [NSNotificationCenter.defaultCenter removeObserver:self];
     

--- a/AGAudioPlayer/UI/AGAudioPlayerViewController.swift
+++ b/AGAudioPlayer/UI/AGAudioPlayerViewController.swift
@@ -199,6 +199,8 @@ extension AGAudioPlayerViewController : UIGestureRecognizerDelegate {
 extension AGAudioPlayerViewController : AGAudioPlayerDelegate {
     func setupPlayer() {
         player.delegate = self
+        player.prepareAudioSession()
+        publishToNowPlayingCenter()
     }
     
     public func audioPlayerAudioSessionSetUp(_ audioPlayer: AGAudioPlayer) {


### PR DESCRIPTION
Relisten needs `MPRemoteCommandCenter` and `MPNowPlayingInfoCenter` set up before the CarPlay UI will appear. Having a hook to prepare the audio session was the easiest way to do this.