### PR TITLE
Fix going backwards a track from the system now playing UI

### DIFF
--- a/AGAudioPlayer/AGAudioPlayer.m
+++ b/AGAudioPlayer/AGAudioPlayer.m
@@ -155,7 +155,7 @@
 
 - (BOOL)backward {
     if(self.elapsed < 5.0f || self.backwardStyle == AGAudioPlayerBackwardStyleAlwaysPrevious) {
-        NSInteger previousIndex = self.nextIndex;
+        NSInteger previousIndex = self.previousIndex;
         
         if(previousIndex == NSNotFound) {
             return NO;


### PR DESCRIPTION
If I tap the << button to seek backwards one track from control center or the now playing view on the lock screen the next track in the queue starts playing instead of the previous track.