### PR TITLE
Show album art in the now playing info center

### DIFF
--- a/AGAudioPlayer/AGAudioItem.h
+++ b/AGAudioPlayer/AGAudioItem.h
@@ -10,7 +10,7 @@
 
 #import "AGAudioItemCollection.h"
 
-@class MPMediaItemArtwork;
+@class MPMediaItemArtwork, UIImage;
 
 @interface AGAudioItem : NSObject
 
@@ -30,7 +30,7 @@
 @property (nonatomic) NSString * _Nonnull displayText;
 @property (nonatomic) NSString * _Nonnull displaySubtext;
 
-@property (nonatomic) NSURL * _Nullable albumArt;
+@property (nonatomic) UIImage * _Nullable albumArt;
 @property (nonatomic) NSURL * _Nonnull playbackURL;
 // @property (nonatomic) NSDictionary *playbackRequestHTTPHeaders;
 

--- a/AGAudioPlayer/AGAudioItem.m
+++ b/AGAudioPlayer/AGAudioItem.m
@@ -7,6 +7,7 @@
 //
 
 #import "AGAudioItem.h"
+#import <UIKit/UIKit.h>
 
 @implementation AGAudioItem
 
@@ -28,7 +29,7 @@
 		self.duration		= [aDecoder decodeDoubleForKey:@"duration"];
 		self.displayText	= [aDecoder decodeObjectForKey:@"displayText"];
 		self.displaySubtext = [aDecoder decodeObjectForKey:@"displaySubtext"];
-        self.albumArt		= [aDecoder decodeObjectForKey:@"albumArt"];
+        self.albumArt		= [aDecoder decodeObjectForKey:@"albumArtImg"];
         self.playbackURL	= [aDecoder decodeObjectForKey:@"playbackURL"];
 	}
 	
@@ -61,7 +62,7 @@
 				  forKey:@"displaySubtext"];
     
     [aCoder encodeObject:self.albumArt
-                  forKey:@"albumArt"];
+                  forKey:@"albumArtImg"];
     
     [aCoder encodeObject:self.playbackURL
                   forKey:@"playbackURL"];

--- a/AGAudioPlayer/AGAudioItemCollection.h
+++ b/AGAudioPlayer/AGAudioItemCollection.h
@@ -8,13 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-@class AGAudioItem;
+@class AGAudioItem, UIImage;
 
 @interface AGAudioItemCollection : NSObject<NSCoding>
 
 @property (nonatomic) NSString * _Nonnull displayText;
 @property (nonatomic) NSString * _Nonnull displaySubtext;
-@property (nonatomic) NSURL * _Nullable albumArt;
+@property (nonatomic) UIImage * _Nullable albumArt;
 
 @property (nonatomic) NSArray * _Nonnull items;
 

--- a/AGAudioPlayer/AGAudioItemCollection.m
+++ b/AGAudioPlayer/AGAudioItemCollection.m
@@ -7,6 +7,7 @@
 //
 
 #import "AGAudioItemCollection.h"
+#import <UIKit/UIKit.h>
 
 @implementation AGAudioItemCollection
 
@@ -21,7 +22,7 @@
 	if (self = [super init]) {
 		self.displayText	= [aDecoder decodeObjectForKey:@"displayText"];
 		self.displaySubtext = [aDecoder decodeObjectForKey:@"displaySubtext"];
-		self.albumArt		= [aDecoder decodeObjectForKey:@"albumArt"];
+		self.albumArt		= [aDecoder decodeObjectForKey:@"albumArtImg"];
 		self.items      	= [aDecoder decodeObjectForKey:@"items"];
 	}
 	
@@ -36,7 +37,7 @@
 				  forKey:@"displaySubtext"];
 	
 	[aCoder encodeObject:self.albumArt
-				  forKey:@"albumArt"];
+				  forKey:@"albumArtImg"];
 	
 	[aCoder encodeObject:self.items
 				  forKey:@"items"];

--- a/AGAudioPlayer/UI/AGAudioPlayerViewController.swift
+++ b/AGAudioPlayer/UI/AGAudioPlayerViewController.swift
@@ -420,6 +420,11 @@ extension AGAudioPlayerViewController : AGAudioPlayerDelegate {
                 MPNowPlayingInfoPropertyPlaybackQueueIndex  : NSNumber(value: player.currentIndex),
                 MPNowPlayingInfoPropertyPlaybackRate        : NSNumber(value: player.isPlaying ? 1.0 : 0.0)
             ]
+            if let albumArt = item.albumArt {
+                nowPlayingInfo![MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: albumArt.size, requestHandler: { (_) -> UIImage in
+                    return albumArt
+                })
+            }
         }
         //print("Updating now playing info to \(nowPlayingInfo)")
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo


### PR DESCRIPTION
This changes `AGAudioItem.albumArt` from `NSURL` to `UIImage`. It didn't look like anything was previously using that property though so I didn't rename it. I changed the name for NSCoding though just in case there was an archived object somewhere.