### PR TITLE
Fix a crash found in crashlytics (http://crashes.to/s/6c8c840c61c)

### DIFF
--- a/AGAudioPlayer/AGAudioPlayer.m
+++ b/AGAudioPlayer/AGAudioPlayer.m
@@ -215,7 +215,12 @@
         [self addHistoryEntry:self.currentItem];
     }
     
-    AGAudioItem * item = [self.queue properQueueForShuffleEnabled:self.shuffle][currentIndex];
+    NSArray<AGAudioItem *> *queue = [self.queue properQueueForShuffleEnabled:self.shuffle];
+    if (currentIndex < 0 || currentIndex > queue.count) {
+        return;
+    }
+    
+    AGAudioItem * item = queue[currentIndex];
     
     [self.bass playURL:item.playbackURL
         withIdentifier:item.playbackGUID];


### PR DESCRIPTION
This is just a bandaid fix to prevent this crash from happening. I'm guessing the crash is happening due to some missing locking around modification of the regular/shuffled queues and the currentIndex variable